### PR TITLE
Added methods to download and extract certified return receipts

### DIFF
--- a/rest_get_Certified_ERRs.rb
+++ b/rest_get_Certified_ERRs.rb
@@ -1,0 +1,5 @@
+require './c2mAPI'
+c2m = C2MAPIRest.new("username","password","0") # set 0 for stage, 1 for production
+c2m.jobId = "440779"
+response = c2m.jobReturnReceiptZip("440779.zip","./return_receipts/")
+c2m.extract_zip("./return_receipts/440779.zip","./return_receipts/440779/")


### PR DESCRIPTION
REST API call /molpro/jobs/<jobId>/returnReceipt returns a zip file. Customer Dalian Banks requested if he could get code to save the response as a zip file and then extract the PDFs in it.